### PR TITLE
refactor:  relate types

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -6,7 +6,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const yargs_1 = __importDefault(require("yargs"));
-const utils_1 = require("./utils");
+const target_1 = require("./utils/target");
+const origin_1 = require("./utils/origin");
 const rename_1 = require("./utils/rename");
 const parsedArgs = (0, yargs_1.default)(process.argv.slice(2))
     .option('origin', {
@@ -38,33 +39,33 @@ const batchRename = (args) => {
     const { origin, prefix, target, startingIndex } = args;
     const { name: originFolderName } = path_1.default.parse(origin);
     const originParent = path_1.default.dirname(origin);
-    const targetFolder = (0, utils_1.getTargetFolder)({
+    const targetFolderName = (0, target_1.getTargetFolderName)({
         target,
         originFolderName,
         originParent,
     });
     console.log(`
     🏁 Origin: ${origin}
-    🎯 Target: ${targetFolder}
+    🎯 Target: ${targetFolderName}
   `);
     if (!fs_1.default.existsSync(origin)) {
         throw new Error(`❌ Origin folder not found: ${originFolderName}`);
     }
     console.log('✅ Found folder:', originFolderName, '\n');
-    (0, utils_1.maybeCreateTargetFolder)(targetFolder);
-    const files = (0, utils_1.retrieveFiles)(origin);
+    (0, target_1.maybeCreateTargetFolder)(targetFolderName);
+    const files = (0, origin_1.retrieveFiles)(origin);
     files.forEach((file, index) => {
         (0, rename_1.renameToNewFile)({
             origin,
-            originalFile: file,
-            targetFolder,
+            originalFileName: file,
+            targetFolderName,
             startingIndex,
             index,
             prefix,
         });
     });
     console.log(`
-    🎉 Done! Renamed files in ${originFolderName} to ${targetFolder} with prefix ${prefix}
+    🎉 Done! Renamed files in ${originFolderName} to ${targetFolderName} with prefix ${prefix}
   `);
 };
 batchRename(parsedArgs);

--- a/build/utils/origin.js
+++ b/build/utils/origin.js
@@ -1,0 +1,20 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.retrieveFiles = void 0;
+const fs_1 = __importDefault(require("fs"));
+/**
+ * Retrieves the files inside the origin folder
+ * @param origin
+ * @returns files
+ */
+const retrieveFiles = (origin) => {
+    const files = fs_1.default.readdirSync(origin);
+    if (!files.length) {
+        throw new Error(`❌ There are no files inside ${origin}`);
+    }
+    return files;
+};
+exports.retrieveFiles = retrieveFiles;

--- a/build/utils/rename.js
+++ b/build/utils/rename.js
@@ -9,7 +9,6 @@ const path_1 = __importDefault(require("path"));
 const FILE_NUMBER_MIN_DIGITS = 3;
 /**
  * Pads the file index with appropriate number of leading zeroes
- * @param fileIndex
  * @returns file index with leading zeroes
  */
 const padWithLeadingZeroes = (fileIndex) => {
@@ -26,9 +25,6 @@ const padWithLeadingZeroes = (fileIndex) => {
 exports.padWithLeadingZeroes = padWithLeadingZeroes;
 /**
  * Creates the file number, taking the starting index into account
- * @param startingIndex
- * @param index
- * @returns file index with leading zeros
  */
 const createFileNumber = (startingIndex, index) => {
     // if no starting index provided, start number at 1 (instead of 0)
@@ -39,8 +35,7 @@ const createFileNumber = (startingIndex, index) => {
 exports.createFileNumber = createFileNumber;
 /**
  * Creates the file name to rename the file as
- * @param targetFileName
- * @returns new file name
+ * @returns new file name with the format `{prefix}_{fileNumber}{extension}`
  */
 const createTargetFileName = ({ prefix, extension, startingIndex, index, }) => {
     const fileNumber = (0, exports.createFileNumber)(startingIndex, index);
@@ -49,18 +44,17 @@ const createTargetFileName = ({ prefix, extension, startingIndex, index, }) => {
 exports.createTargetFileName = createTargetFileName;
 /**
  * Renames a given file
- * @param props
  */
-const renameToNewFile = ({ origin, originalFile, targetFolder, startingIndex, index, prefix, }) => {
-    const extension = path_1.default.extname(originalFile);
-    const basename = path_1.default.basename(originalFile, extension);
+const renameToNewFile = ({ origin, originalFileName, targetFolderName, startingIndex, index, prefix, }) => {
+    const extension = path_1.default.extname(originalFileName);
+    const basename = path_1.default.basename(originalFileName, extension);
     const targetFile = (0, exports.createTargetFileName)({
         prefix,
         extension,
         startingIndex,
         index,
     });
-    fs_1.default.copyFileSync(`${origin}/${originalFile}`, `${targetFolder}/${targetFile}`);
+    fs_1.default.copyFileSync(`${origin}/${originalFileName}`, `${targetFolderName}/${targetFile}`);
     console.log('🗂 ', basename, extension, '→ 🗳 ', targetFile);
 };
 exports.renameToNewFile = renameToNewFile;

--- a/build/utils/target.js
+++ b/build/utils/target.js
@@ -3,17 +3,15 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.retrieveFiles = exports.maybeCreateTargetFolder = exports.getTargetFolder = void 0;
+exports.maybeCreateTargetFolder = exports.getTargetFolderName = void 0;
 const fs_1 = __importDefault(require("fs"));
 /**
  * Creates the absolute path to the target folder.
  * If no target was provided by the user,
  * appends `_renamed` to the original folder name
  * and uses that as the target folder name.
- * @param props
- * @returns
  */
-const getTargetFolder = ({ target, originFolderName, originParent, }) => {
+const getTargetFolderName = ({ target, originFolderName, originParent, }) => {
     // if not target path not provided,
     // use original name with `_renamed` appended
     const backupTargetFolderName = `${originFolderName}_renamed`;
@@ -21,7 +19,7 @@ const getTargetFolder = ({ target, originFolderName, originParent, }) => {
     const targetFolder = target || `${originParent}/${backupTargetFolderName}`;
     return targetFolder;
 };
-exports.getTargetFolder = getTargetFolder;
+exports.getTargetFolderName = getTargetFolderName;
 /**
  * Creates the target folder if it doesn't already exist
  * @param targetFolder absolute path to the target folder
@@ -33,16 +31,3 @@ const maybeCreateTargetFolder = (targetFolder) => {
     }
 };
 exports.maybeCreateTargetFolder = maybeCreateTargetFolder;
-/**
- * Retrieves the files inside the origin folder
- * @param origin
- * @returns files
- */
-const retrieveFiles = (origin) => {
-    const files = fs_1.default.readdirSync(origin);
-    if (!files.length) {
-        throw new Error(`❌ There are no files inside ${origin}`);
-    }
-    return files;
-};
-exports.retrieveFiles = retrieveFiles;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "batch-rename": "node build/",
     "test": "jest",
     "test:watch": "yarn run test --watch",
-    "build": "tsc -p tsconfig.build.json"
+    "build": "rm -rf build && tsc -p tsconfig.build.json"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.16.7",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import yargs from 'yargs';
-import type { ExpectedArguments } from 'src/types';
+import type { CommandArguments } from 'src/types';
 import {
   getTargetFolder,
   maybeCreateTargetFolder,
@@ -9,7 +9,7 @@ import {
 } from './utils';
 import { renameToNewFile } from './utils/rename';
 
-const parsedArgs: ExpectedArguments = yargs(process.argv.slice(2))
+const parsedArgs: CommandArguments = yargs(process.argv.slice(2))
   .option('origin', {
     alias: 'o',
     type: 'string',
@@ -42,7 +42,7 @@ const parsedArgs: ExpectedArguments = yargs(process.argv.slice(2))
   )
   .parse(process.argv.slice(2));
 
-const batchRename = (args: ExpectedArguments): void => {
+const batchRename = (args: CommandArguments): void => {
   const { origin, prefix, target, startingIndex } = args;
 
   const { name: originFolderName } = path.parse(origin);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import yargs from 'yargs';
 import type { CommandArguments } from 'src/types';
 import {
-  getTargetFolder,
+  getTargetFolderName,
   maybeCreateTargetFolder,
 } from './utils/target';
 import { retrieveFiles } from './utils/origin';
@@ -49,7 +49,7 @@ const batchRename = (args: CommandArguments): void => {
 
   const originParent = path.dirname(origin);
 
-  const targetFolder = getTargetFolder({
+  const targetFolderName = getTargetFolderName({
     target,
     originFolderName,
     originParent,
@@ -57,7 +57,7 @@ const batchRename = (args: CommandArguments): void => {
 
   console.log(`
     🏁 Origin: ${origin}
-    🎯 Target: ${targetFolder}
+    🎯 Target: ${targetFolderName}
   `);
 
   if (!fs.existsSync(origin)) {
@@ -66,7 +66,7 @@ const batchRename = (args: CommandArguments): void => {
 
   console.log('✅ Found folder:', originFolderName, '\n');
 
-  maybeCreateTargetFolder(targetFolder);
+  maybeCreateTargetFolder(targetFolderName);
 
   const files = retrieveFiles(origin);
 
@@ -74,7 +74,7 @@ const batchRename = (args: CommandArguments): void => {
     renameToNewFile({
       origin,
       originalFileName: file,
-      targetFolder,
+      targetFolderName,
       startingIndex,
       index,
       prefix,
@@ -82,7 +82,7 @@ const batchRename = (args: CommandArguments): void => {
   });
 
   console.log(`
-    🎉 Done! Renamed files in ${originFolderName} to ${targetFolder} with prefix ${prefix}
+    🎉 Done! Renamed files in ${originFolderName} to ${targetFolderName} with prefix ${prefix}
   `);
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import type { CommandArguments } from 'src/types';
 import {
   getTargetFolder,
   maybeCreateTargetFolder,
-  retrieveFiles,
-} from './utils';
+} from './utils/target';
+import { retrieveFiles } from './utils/origin';
 import { renameToNewFile } from './utils/rename';
 
 const parsedArgs: CommandArguments = yargs(process.argv.slice(2))
@@ -73,7 +73,7 @@ const batchRename = (args: CommandArguments): void => {
   files.forEach((file: string, index: number): void => {
     renameToNewFile({
       origin,
-      originalFile: file,
+      originalFileName: file,
       targetFolder,
       startingIndex,
       index,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,28 +1,31 @@
-export type CommandArguments = {
-  origin: string;
+type TargetFileNameBaseParams = {
   prefix: string;
   startingIndex: number;
-  target: string | null;
+}
+
+type TargetPath = string | null;
+
+export type CommandArguments = TargetFileNameBaseParams & {
+  origin: string;
+  target: TargetPath;
 }
 
 export type TargetFolder = {
   originFolderName: string;
   originParent: string;
-  target: string | null;
+  target: TargetPath;
 }
 
-export type TargetFile = {
+type TargetFileName = TargetFileNameBaseParams & {
+  index: number; 
+}
+
+export type TargetFile = TargetFileName & {
   extension: string;
-  index: number;
-  prefix: string;
-  startingIndex: number;
 }
 
-export type NewFileRenameProps = {
-  index: number;
+export type NewFileRenameProps = TargetFileName & {
   origin: string;
   originalFileName: string;
-  prefix: string;
-  startingIndex: number;
-  targetFolder: string;
+  targetFolderName: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,28 +1,28 @@
-export type ExpectedArguments = {
+export type CommandArguments = {
   origin: string;
   prefix: string;
-  target: string | null;
   startingIndex: number;
+  target: string | null;
 }
 
 export type TargetFolder = {
-  target: string | null;
   originFolderName: string;
   originParent: string;
+  target: string | null;
 }
 
-export type TargetFileName = {
-  prefix: string;
+export type TargetFile = {
   extension: string;
-  startingIndex: number;
-  index: number;
-}
-
-export type NewFileRenameInput = {
-  origin: string;
-  originalFile: string;
-  targetFolder: string;
-  startingIndex: number;
   index: number;
   prefix: string;
+  startingIndex: number;
+}
+
+export type NewFileRenameProps = {
+  index: number;
+  origin: string;
+  originalFileName: string;
+  prefix: string;
+  startingIndex: number;
+  targetFolder: string;
 }

--- a/src/utils/__tests__/origin.test.ts
+++ b/src/utils/__tests__/origin.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import { retrieveFiles } from '../origin';
+
+describe('utils > origin', () => {
+  describe('retrieveFiles', () => {
+    let readdirSyncSpy: jest.Mock;
+    beforeEach(() => {
+      readdirSyncSpy = jest.spyOn(fs, 'readdirSync') as jest.Mock;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('returns the files from the origin folder if they exist', () => {
+      const mockFiles = ['/folder/1', '/folder/2', '/folder/3'];
+      readdirSyncSpy.mockReturnValueOnce(mockFiles);
+
+      const result = retrieveFiles('/some/origin');
+      expect(result).toEqual(mockFiles);
+    });
+
+    it("throws an error if files don't exist", () => {
+      const mockFiles: string[] = []; // empty
+      readdirSyncSpy.mockReturnValueOnce(mockFiles);
+
+      expect(() => {
+        retrieveFiles('/some/origin');
+      }).toThrow();
+    });
+  });
+});

--- a/src/utils/__tests__/origin.test.ts
+++ b/src/utils/__tests__/origin.test.ts
@@ -4,6 +4,7 @@ import { retrieveFiles } from '../origin';
 describe('utils > origin', () => {
   describe('retrieveFiles', () => {
     let readdirSyncSpy: jest.Mock;
+    
     beforeEach(() => {
       readdirSyncSpy = jest.spyOn(fs, 'readdirSync') as jest.Mock;
     });

--- a/src/utils/__tests__/rename.test.ts
+++ b/src/utils/__tests__/rename.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { NewFileRenameProps } from '../../types';
 import {
   padWithLeadingZeroes,
   createFileNumber,
@@ -99,10 +100,10 @@ describe('utils/rename', () => {
 
   describe('renameToNewFile', () => {
     it('copies the original file to a new folder with specified prefix', () => {
-      const args = {
+      const args: NewFileRenameProps = {
         origin: '/originFolder',
-        originalFile: 'original.js',
-        targetFolder: '/targetFolder',
+        originalFileName: 'original.js',
+        targetFolderName: '/targetFolder',
         startingIndex: 0,
         index: 0,
         prefix: 'prefix',

--- a/src/utils/__tests__/target.test.ts
+++ b/src/utils/__tests__/target.test.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
-import { getTargetFolder, maybeCreateTargetFolder } from '../target';
+import { getTargetFolderName, maybeCreateTargetFolder } from '../target';
 
 describe('utils > target', () => {
-  describe('getTargetFolder', () => {
+  describe('getTargetFolderName', () => {
     const originFolderName = 'original';
     const originParent = 'base/path';
     it('returns target folder specified by user if it was provided', () => {
       const target = 'my/path/to/target';
-      const result = getTargetFolder({
+      const result = getTargetFolderName({
         target,
         originFolderName,
         originParent,
@@ -17,7 +17,7 @@ describe('utils > target', () => {
     });
 
     it('uses the original folder name with "_renamed" if target folder was not specified by user ', () => {
-      const result = getTargetFolder({
+      const result = getTargetFolderName({
         target: null,
         originFolderName,
         originParent,
@@ -30,6 +30,7 @@ describe('utils > target', () => {
   describe('maybeCreateTargetFolder', () => {
     let existsSyncSpy: jest.Mock;
     let mkdirSyncSpy: jest.Mock;
+    
     beforeEach(() => {
       existsSyncSpy = jest.spyOn(fs, 'existsSync') as jest.Mock;
       mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync') as jest.Mock;

--- a/src/utils/__tests__/target.test.ts
+++ b/src/utils/__tests__/target.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
-import { getTargetFolder, maybeCreateTargetFolder, retrieveFiles } from '..';
+import { getTargetFolder, maybeCreateTargetFolder } from '../target';
 
-describe('utils', () => {
+describe('utils > target', () => {
   describe('getTargetFolder', () => {
     const originFolderName = 'original';
     const originParent = 'base/path';
@@ -56,34 +56,6 @@ describe('utils', () => {
       maybeCreateTargetFolder(targetFolder);
 
       expect(mkdirSyncSpy).toHaveBeenCalledWith(targetFolder);
-    });
-  });
-
-  describe('retrieveFiles', () => {
-    let readdirSyncSpy: jest.Mock;
-    beforeEach(() => {
-      readdirSyncSpy = jest.spyOn(fs, 'readdirSync') as jest.Mock;
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    it('returns the files from the origin folder if they exist', () => {
-      const mockFiles = ['/folder/1', '/folder/2', '/folder/3'];
-      readdirSyncSpy.mockReturnValueOnce(mockFiles);
-
-      const result = retrieveFiles('/some/origin');
-      expect(result).toEqual(mockFiles);
-    });
-
-    it("throws an error if files don't exist", () => {
-      const mockFiles: string[] = []; // empty
-      readdirSyncSpy.mockReturnValueOnce(mockFiles);
-
-      expect(() => {
-        retrieveFiles('/some/origin');
-      }).toThrow();
     });
   });
 });

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+/**
+ * Retrieves the files inside the origin folder
+ * @param origin
+ * @returns files
+ */
+export const retrieveFiles = (origin: string): string[] => {
+  const files = fs.readdirSync(origin);
+
+  if (!files.length) {
+    throw new Error(`❌ There are no files inside ${origin}`);
+  }
+
+  return files;
+};

--- a/src/utils/origin.ts
+++ b/src/utils/origin.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+
 /**
  * Retrieves the files inside the origin folder
  * @param origin

--- a/src/utils/rename.ts
+++ b/src/utils/rename.ts
@@ -59,7 +59,7 @@ export const createTargetFileName = ({
 export const renameToNewFile = ({
   origin,
   originalFileName,
-  targetFolder,
+  targetFolderName,
   startingIndex,
   index,
   prefix,
@@ -74,7 +74,7 @@ export const renameToNewFile = ({
     index,
   });
 
-  fs.copyFileSync(`${origin}/${originalFileName}`, `${targetFolder}/${targetFile}`);
+  fs.copyFileSync(`${origin}/${originalFileName}`, `${targetFolderName}/${targetFile}`);
 
   console.log('🗂 ', basename, extension, '→ 🗳 ', targetFile);
 };

--- a/src/utils/rename.ts
+++ b/src/utils/rename.ts
@@ -1,12 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import type { TargetFileName, NewFileRenameInput } from 'src/types';
+import type { TargetFile, NewFileRenameProps } from 'src/types';
 
 const FILE_NUMBER_MIN_DIGITS = 3;
 
 /**
  * Pads the file index with appropriate number of leading zeroes
- * @param fileIndex
  * @returns file index with leading zeroes
  */
 export const padWithLeadingZeroes = (fileIndex: number): string => {
@@ -26,9 +25,6 @@ export const padWithLeadingZeroes = (fileIndex: number): string => {
 
 /**
  * Creates the file number, taking the starting index into account
- * @param startingIndex
- * @param index
- * @returns file index with leading zeros
  */
 export const createFileNumber = (
   startingIndex: number,
@@ -44,15 +40,14 @@ export const createFileNumber = (
 
 /**
  * Creates the file name to rename the file as
- * @param targetFileName
- * @returns new file name
+ * @returns new file name with the format `{prefix}_{fileNumber}{extension}`
  */
 export const createTargetFileName = ({
   prefix,
   extension,
   startingIndex,
   index,
-}: TargetFileName): string => {
+}: TargetFile): string => {
   const fileNumber = createFileNumber(startingIndex, index);
 
   return `${prefix}-${fileNumber}${extension}`;
@@ -60,18 +55,17 @@ export const createTargetFileName = ({
 
 /**
  * Renames a given file
- * @param props
  */
 export const renameToNewFile = ({
   origin,
-  originalFile,
+  originalFileName,
   targetFolder,
   startingIndex,
   index,
   prefix,
-}: NewFileRenameInput): void => {
-  const extension = path.extname(originalFile);
-  const basename = path.basename(originalFile, extension);
+}: NewFileRenameProps): void => {
+  const extension = path.extname(originalFileName);
+  const basename = path.basename(originalFileName, extension);
 
   const targetFile = createTargetFileName({
     prefix,
@@ -80,7 +74,7 @@ export const renameToNewFile = ({
     index,
   });
 
-  fs.copyFileSync(`${origin}/${originalFile}`, `${targetFolder}/${targetFile}`);
+  fs.copyFileSync(`${origin}/${originalFileName}`, `${targetFolder}/${targetFile}`);
 
   console.log('🗂 ', basename, extension, '→ 🗳 ', targetFile);
 };

--- a/src/utils/target.ts
+++ b/src/utils/target.ts
@@ -6,10 +6,8 @@ import type { TargetFolder } from 'src/types';
  * If no target was provided by the user,
  * appends `_renamed` to the original folder name
  * and uses that as the target folder name.
- * @param props
- * @returns
  */
-export const getTargetFolder = ({
+export const getTargetFolderName = ({
   target,
   originFolderName,
   originParent,

--- a/src/utils/target.ts
+++ b/src/utils/target.ts
@@ -35,17 +35,3 @@ export const maybeCreateTargetFolder = (targetFolder: string): void => {
   }
 };
 
-/**
- * Retrieves the files inside the origin folder
- * @param origin
- * @returns files
- */
-export const retrieveFiles = (origin: string): string[] => {
-  const files = fs.readdirSync(origin);
-
-  if (!files.length) {
-    throw new Error(`❌ There are no files inside ${origin}`);
-  }
-
-  return files;
-};


### PR DESCRIPTION
- Uses intersection types to relate types
- Renames types for better clarity
- Renames and recategorizes `utils` files
- Updates `build` script to create a new `build` folder every time